### PR TITLE
Add force parameter to deleteAllTerms for proper deletion.

### DIFF
--- a/src/taxonomies/index.js
+++ b/src/taxonomies/index.js
@@ -84,7 +84,7 @@ export const deleteAllTerms = async ( requestUtils, taxonomy ) => {
 	await requestUtils.batchRest(
 		terms.map( ( term ) => ( {
 			method: 'DELETE',
-			path: `${ BASE_PATH }/${ taxonomy }/${ term.id }`,
+			path: `${ BASE_PATH }/${ taxonomy }/${ term.id }?force=true`,
 		} ) )
 	);
 };


### PR DESCRIPTION
## What

The `deleteAllTerms()` function was not properly deleting terms between test runs, causing test pollution and flaky tests.

## Why

The WordPress REST API requires the `force=true` parameter when deleting terms via the API. Without it, the API returns a 501 error:

> "Terms do not support trashing. Set force=true to delete.", see https://github.com/WordPress/wordpress-develop/blob/6.9.0/src/wp-includes/rest-api/endpoints/class-wp-rest-terms-controller.php#L783.

## Fix

Add `?force=true` to the DELETE request path in `deleteAllTerms()`: