### PR TITLE
Disable editors welcome guides in global setup

### DIFF
--- a/src/setup/global.setup.js
+++ b/src/setup/global.setup.js
@@ -52,6 +52,12 @@ export default async function globalSetup( config ) {
 					'core/edit-widgets': {
 						welcomeGuide: false,
 					},
+					'core/edit-site': {
+						welcomeGuide: false,
+						welcomeGuideStyles: false,
+						welcomeGuidePage: false,
+						welcomeGuideTemplate: false,
+					},
 				},
 			},
 		},

--- a/src/setup/global.setup.js
+++ b/src/setup/global.setup.js
@@ -37,5 +37,25 @@ export default async function globalSetup( config ) {
 		resetAllSettings( requestUtils ),
 	] );
 
+	// Disable editors welcome guides globally for all projects.
+	// Must be called after resetPreferences() which would otherwise overwrite this.
+	await requestUtils.rest( {
+		path: '/wp/v2/users/me',
+		method: 'PUT',
+		data: {
+			meta: {
+				persisted_preferences: {
+					'core/edit-post': {
+						welcomeGuide: false,
+						welcomeGuideTemplate: false,
+					},
+					'core/edit-widgets': {
+						welcomeGuide: false,
+					},
+				},
+			},
+		},
+	} );
+
 	await requestContext.dispose();
 }

--- a/src/setup/global.setup.js
+++ b/src/setup/global.setup.js
@@ -48,6 +48,7 @@ export default async function globalSetup( config ) {
 					'core/edit-post': {
 						welcomeGuide: false,
 						welcomeGuideTemplate: false,
+						fullscreenMode: false,
 					},
 					'core/edit-widgets': {
 						welcomeGuide: false,


### PR DESCRIPTION
Following https://github.com/polylang/polylang-pro/pull/2984#discussion_r3050662642.

## What
Set `welcomeGuide`, `welcomeGuideTemplate` (`core/edit-post`) and `welcomeGuide` (`core/edit-widgets`) to `false` in `global.setup.js` via a REST call to `PUT /wp/v2/users/me`.

## Why
Several specs across Polylang Pro and Polylang were dismissing the block editor and widget editor welcome guides inline, either via `editor.setPreferences()` or by clicking the close button.

Moving this to global setup removes the need to handle it in each spec.

## How
The REST call is placed after the `Promise.all()` block.

This is intentional: `resetPreferences()` runs inside that block and makes a `PUT /wp/v2/users/me` with `persisted_preferences: {}`, which would overwrite our values.